### PR TITLE
switched messages link to sign out in navbar and added sign out functionality

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,7 +15,7 @@
             <%= link_to "Home", "#", class: "nav-link" %>
           </li>
           <li class="nav-item">
-            <%= link_to "Messages", "#", class: "nav-link" %>
+            <%= link_to "Sign Out", destroy_user_session_path, :method => :delete, class: "nav-link" %>
           </li>
           <li class="nav-item dropdown">
             <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>


### PR DESCRIPTION
For some reason the drop down menu from the avatar photo isn't working - I guess maybe that there is a javascript setting somewhere that needs adjusting.

Anyway it meant that the logout button wasn't accessible so I've changed the messages link (don't think we'll need that for this project) to logout and added the functionality in the navbar partial view.